### PR TITLE
Add support for Gnome 3.24 and 3.26.

### DIFF
--- a/disconnect-wifi@kgshank.net/convenience.js
+++ b/disconnect-wifi@kgshank.net/convenience.js
@@ -84,7 +84,8 @@ var SignalManager = new Lang.Class({
             if(!this._signalsBySource[signalSource]) {
             	this._signalsBySource[signalSource] = [];
             }
-            this._signalsBySource[signalSource].push(obj)
+            let item = this._signalsBySource[signalSource];
+            item.push(obj);
         }
 		return obj;
     },
@@ -95,7 +96,8 @@ var SignalManager = new Lang.Class({
     
     disconnectBySource: function(signalSource) {
     	if(this._signalsBySource[signalSource]) {
-    		this._signalsBySource[signalSource].forEach(function(obj) {obj.disconnect();});
+            let signalBySource = this._signalsBySource[signalSource];
+            signalBySource.forEach(function(obj) {obj.disconnect();});
         }
     }
 });

--- a/disconnect-wifi@kgshank.net/convenience.js
+++ b/disconnect-wifi@kgshank.net/convenience.js
@@ -67,7 +67,7 @@ const Signal = new Lang.Class({
     }
 });
 
-const SignalManager = new Lang.Class({
+var SignalManager = new Lang.Class({
 	Name: 'SignalManager',
 
 	_init: function() {

--- a/disconnect-wifi@kgshank.net/extension.js
+++ b/disconnect-wifi@kgshank.net/extension.js
@@ -170,9 +170,10 @@ const WifiDisconnector = new Lang.Class({
                     = (newstate == NetworkManager.DeviceState.DISCONNECTED) 
                          && (this._activeConnections[device] != null);
             
+            let accessPoint = this._accessPoints[device];
             wrapper.reconnectItem.label.text = 
-                    (this._accessPoints[device]) ?  _(RECONNECT_TEXT) + SPACE 
-                    + imports.ui.status.network.ssidToLabel(this._accessPoints[device].get_ssid()) : _(RECONNECT_TEXT) ;
+                    (accessPoint) ?  _(RECONNECT_TEXT) + SPACE 
+                    + imports.ui.status.network.ssidToLabel(accessPoint.get_ssid()) : _(RECONNECT_TEXT) ;
         }
      },
         

--- a/disconnect-wifi@kgshank.net/extension.js
+++ b/disconnect-wifi@kgshank.net/extension.js
@@ -208,9 +208,11 @@ const WifiDisconnector = new Lang.Class({
     },
 
     destroy : function() {
-    	this._network._nmDevices.forEach(function(device){
-        	this._deviceRemoved(this._client, device);
-        }, this);
+        if (this._network._nmDevices) {
+            this._network._nmDevices.forEach(function(device){
+                this._deviceRemoved(this._client, device);
+            }, this);
+        }
         this._signalManager.disconnectAll();
     }
 });

--- a/disconnect-wifi@kgshank.net/metadata.json
+++ b/disconnect-wifi@kgshank.net/metadata.json
@@ -5,7 +5,9 @@
         "3.16",
         "3.18",
         "3.20",
-        "3.22"
+        "3.22",
+        "3.24",
+        "3.26"
     ], 
     "uuid": "disconnect-wifi@kgshank.net", 
     "name": "Disconnect Wifi", 


### PR DESCRIPTION
Fix a small warning: use 'var' instead of 'const' for object that is called from another module.

Example warning in Gnome 3.26 with MozJS 52:

```
gnome-shell[1663]: Some code accessed the property 'SignalManager' on the module
'convenience'. That property was defined with 'let' or 'const' inside the module. This
was previously supported, but is not correct according to the ES6 standard. Any symbols
to be exported from a module must be defined with 'var'. The property access will work
as previously for the time being, but please fix your code anyway.
```