### PR TITLE
Add Gnome 41 shell as supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ rm -rf "gse-disconnect-wifi"
 Enable the extensions from [GNOME Tweaks](https://wiki.gnome.org/Apps/Tweaks).
 
 ### Gnome shell versions compatible
+* 41
 * 40
 * 3.38
 * 3.36

--- a/disconnect-wifi@kgshank.net/metadata.json
+++ b/disconnect-wifi@kgshank.net/metadata.json
@@ -4,7 +4,8 @@
         "3.34",
         "3.36",
         "3.38",
-        "40"
+        "40",
+        "41"
     ], 
     "uuid": "disconnect-wifi@kgshank.net", 
     "name": "Disconnect Wifi", 


### PR DESCRIPTION
Adds 41 as a supported shell. Seems to work fine for me with just this change (Arch running Gnome 41.1).